### PR TITLE
fix: continue read when cvm returns launch failed (#1077)

### DIFF
--- a/tencentcloud/commom_test.go
+++ b/tencentcloud/commom_test.go
@@ -115,13 +115,15 @@ func TestIsExpectError(t *testing.T) {
 
 	err := sdkErrors.NewTencentCloudSDKError("ClientError.NetworkError", "", "")
 
+	// Expected
 	expectedFull := []string{"ClientError.NetworkError"}
 	expectedShort := []string{"ClientError"}
-	unExpectedMatchHead := []string{"ClientError.HttpStatusCodeError"}
-	unExpectedShort := []string{"SystemError"}
-
 	assert.Equalf(t, isExpectError(err, expectedFull), true, "")
 	assert.Equalf(t, isExpectError(err, expectedShort), true, "")
+
+	// Unexpected
+	unExpectedMatchHead := []string{"ClientError.HttpStatusCodeError"}
+	unExpectedShort := []string{"SystemError"}
 	assert.Equalf(t, isExpectError(err, unExpectedMatchHead), false, "")
 	assert.Equalf(t, isExpectError(err, unExpectedShort), false, "")
 }

--- a/tencentcloud/extension_cvm.go
+++ b/tencentcloud/extension_cvm.go
@@ -49,7 +49,9 @@ const (
 	CVM_IMAGE_LOGIN     = "TRUE"
 	CVM_IMAGE_LOGIN_NOT = "FALSE"
 
-	CVM_ZONE_NOT_SUPPORT_ERROR    = "InvalidParameterValue.ZoneNotSupported"
+	// @Deprecated use cvm.INVALIDPARAMETERVALUE_ZONENOTSUPPORTED
+	CVM_ZONE_NOT_SUPPORT_ERROR = "InvalidParameterValue.ZoneNotSupported"
+	// @Deprecated use cvm.RESOURCEINSUFFICIENT_CLOUDDISKSOLDOUT instead
 	CVM_CLOUD_DISK_SOLD_OUT_ERROR = "ResourceInsufficient.CloudDiskSoldOut"
 
 	CVM_STOP_MODE_KEEP_CHARGING = "KEEP_CHARGING"
@@ -59,6 +61,13 @@ const (
 	MIDLINE                     = "-"
 	UNDERLINE                   = "_"
 )
+
+// Only client error can cvm retry, others will directly returns
+var CVM_RETRYABLE_ERROR = []string{
+	// client
+	"ClientError.NetworkError",
+	"ClientError.HttpStatusCodeError",
+}
 
 var CVM_CHARGE_TYPE = []string{
 	CVM_CHARGE_TYPE_PREPAID,


### PR DESCRIPTION
* fix: continue read when cvm returns launch failed

* fix: cvm use tag service to read instance tag

* fix: cvm - make cvm errors non retryable